### PR TITLE
fix: fall back to pool labels in default work queries

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -193,6 +193,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat")
 
 	origWD, err := os.Getwd()
@@ -261,6 +262,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat-1")
 	t.Setenv("GC_SESSION_NAME", "myrig--polecat-1")
 
@@ -313,6 +315,7 @@ name = "worker"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "")
 	t.Setenv("GC_SESSION_NAME", "")
 
@@ -368,6 +371,7 @@ dir = "myrig"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_DIR", rigDir)
 	t.Setenv("GC_AGENT", "")
 	t.Setenv("GC_SESSION_NAME", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1313,6 +1313,8 @@ func (a *Agent) AttachEnabled() bool {
 // EffectiveWorkQuery returns the work query command for this agent.
 // If WorkQuery is set, returns it as-is. Otherwise returns the default:
 // "bd ready --metadata-field gc.routed_to=<template> --unassigned --json --limit=1"
+// with a fallback to check labels (pool:<template>) for beads dispatched
+// via `bd update --add-label pool:<pool>`.
 //
 // All agents use metadata-based routing via gc.routed_to. The template
 // name (QualifiedName or PoolName for rig-scoped instances) determines
@@ -1325,7 +1327,8 @@ func (a *Agent) EffectiveWorkQuery() string {
 	if a.PoolName != "" {
 		target = a.PoolName
 	}
-	return "bd ready --metadata-field gc.routed_to=" + target + " --unassigned --json --limit=1 2>/dev/null"
+	// Check metadata first, fall back to label
+	return "bd ready --metadata-field gc.routed_to=" + target + " --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:" + target + " --unassigned --json --limit=1 2>/dev/null"
 }
 
 // EffectiveSlingQuery returns the sling query command template for this agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1147,7 +1147,7 @@ func TestPoolRoundTrip(t *testing.T) {
 func TestEffectiveWorkQueryDefault(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQuery()
-	want := "bd ready --metadata-field gc.routed_to=mayor --unassigned --json --limit=1 2>/dev/null"
+	want := "bd ready --metadata-field gc.routed_to=mayor --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:mayor --unassigned --json --limit=1 2>/dev/null"
 	if got != want {
 		t.Errorf("EffectiveWorkQuery() = %q, want %q", got, want)
 	}
@@ -1165,7 +1165,7 @@ func TestEffectiveWorkQueryCustom(t *testing.T) {
 func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world"}
 	got := a.EffectiveWorkQuery()
-	want := "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1 2>/dev/null"
+	want := "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:hello-world/polecat --unassigned --json --limit=1 2>/dev/null"
 	if got != want {
 		t.Errorf("EffectiveWorkQuery() = %q, want %q", got, want)
 	}
@@ -1174,7 +1174,7 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	want := "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1 2>/dev/null"
+	want := "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:hello-world/polecat --unassigned --json --limit=1 2>/dev/null"
 	if got != want {
 		t.Errorf("EffectiveWorkQuery() = %q, want %q", got, want)
 	}
@@ -1226,7 +1226,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	got := a.EffectiveWorkQuery()
-	want := "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1 2>/dev/null"
+	want := "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:hello-world/dog --unassigned --json --limit=1 2>/dev/null"
 	if got != want {
 		t.Errorf("EffectiveWorkQuery() = %q, want %q", got, want)
 	}
@@ -1235,7 +1235,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	a := Agent{Name: "dog", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	want := "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1 2>/dev/null"
+	want := "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1 2>/dev/null || bd ready --label pool:hello-world/dog --unassigned --json --limit=1 2>/dev/null"
 	if got != want {
 		t.Errorf("EffectiveWorkQuery() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- make the default agent work query fall back from `gc.routed_to` metadata to `pool:<target>` labels
- keep the metadata path first so normal dispatch stays unchanged
- update hook/config tests to cover the fallback and isolate hook env from ambient `GC_ALIAS`

## Testing
- go test ./internal/config -run 'TestEffectiveWorkQuery(Default|WithDir|PoolDefault|PoolNameOverride|PoolNoPoolName)'
- go test ./cmd/gc -run 'Test(DoSlingBeadToPool|DoSlingFormulaToAgent|OnFormulaAttachesAndRoutes|DefaultFormulaApplied|CmdHookUsesAgentCityAndRigRoot|CmdHookPoolInstanceUsesTemplatePoolLabel|CmdHookExportsResolvedIdentityForFixedAgentQuery|CmdHookExportsResolvedIdentityFromRigContext)'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback mechanism to work query system: when metadata-based routing is unavailable, the system now attempts discovery using label-based routing, improving reliability.

* **Tests**
  * Updated test expectations and setup to verify new fallback behavior and validate hook execution with cleared environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->