### PR TITLE
fix: add label fallback to polecat work query

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -201,6 +201,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat")
 
 	origWD, err := os.Getwd()
@@ -525,6 +526,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat-1")
 	t.Setenv("GC_SESSION_NAME", "myrig--polecat-1")
 
@@ -600,6 +602,9 @@ name = "worker"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_SESSION_NAME", "")
 
 	var stdout, stderr bytes.Buffer
 	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
@@ -656,6 +661,7 @@ dir = "myrig"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_DIR", rigDir)
 
 	wantAgent := "myrig/worker"

--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -232,7 +232,22 @@ Use an exec order before inventing a plugin, helper role, or hidden session.
 
 That is the direct Gas City answer to many old Town automation tasks.
 
-## Common Gastown Overrides In PackV2
+### "How do I get to my mayor?"
+
+```bash
+gc session attach mayor
+```
+
+The Mayor session is the primary Gas Town experience — an interactive Claude
+session with full city context that coordinates everything. The CLI is
+plumbing; this is the product.
+
+City-scoped agents from the Gastown pack — `mayor`, `deacon`, `boot` — are all
+accessible the same way. Use `gc session list` to see what is running.
+
+This replaces `gt session at mayor/` or `tmux attach -t gt-mayor` from Gas Town.
+
+## Common Gastown Overrides In `city.toml`
 
 If you are using the Gastown pack, these are the most common local changes.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1762,7 +1762,9 @@ func (a *Agent) AttachEnabled() bool {
 
 // EffectiveWorkQuery returns the work query command for this agent.
 // If WorkQuery is set, returns it as-is. Otherwise returns the default
-// three-tier query with multi-identifier assignee resolution.
+// three-tier query with multi-identifier assignee resolution. Tier 3 also
+// falls back to label-based routing (pool:<target>) for beads dispatched
+// via `bd update --add-label pool:<pool>`.
 //
 // Assignee resolution order: $GC_SESSION_ID (bead ID) > $GC_SESSION_NAME
 // (tmux session name) > $GC_ALIAS (named identity / qualified name).
@@ -1805,6 +1807,11 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`*) exit 0 ;; ` +
 			`esac; ` +
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
+			` --unassigned --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			// Tier 3.5: label-dispatched beads (pool:<target>) — fallback for beads
+			// routed via `bd update --add-label pool:<pool>` instead of metadata.
+			`r=$(bd ready --label pool:` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			// Tier 4: open routed molecule roots. scale_check already counts

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1288,9 +1288,12 @@ func TestPoolRoundTrip(t *testing.T) {
 func TestEffectiveWorkQueryDefault(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQuery()
-	// Tiered query: check that tier 3 (routed_to) and tier 1-2 (assignee resolution) are present.
+	// Tiered query: check tier 3 (routed_to), tier 3.5 (label fallback), and tier 1-2 (assignee resolution).
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:mayor --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
@@ -1312,6 +1315,9 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
+	}
 }
 
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
@@ -1319,6 +1325,9 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
 	}
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/polecat --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route: %q", got)
@@ -1373,6 +1382,9 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback with pool name: %q", got)
+	}
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/dog --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route with pool name: %q", got)
 	}
@@ -1383,6 +1395,9 @@ func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes dispatcher routing bug blocking pool-based dispatch.

Root: Polecat work query only checks metadata (`gc.routed_to`), ignores label-based dispatch (`pool:<pool>`).

Fix: Add label fallback.

Impact: Unblocks sa-ml2 orphan loop (19 recoveries), dispatcher for newly spawned polecats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance with explicit CLI instructions for accessing Gastown agents via session attach commands.

* **Bug Fixes**
  * Improved work-query reliability by adding a fallback mechanism that uses label-based routing when metadata routing is unavailable.

* **Tests**
  * Enhanced test isolation by explicitly clearing environment variables in hook and config test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->