### PR TITLE
fix: remove gc handoff from PreCompact hook; disable Dolt auto-archive

### DIFF
--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -134,8 +134,8 @@ data_dir: %q
 
 behavior:
   auto_gc_behavior:
-    enable: true
-    archive_level: 1
+    enable: false
+    archive_level: 0
 `, logLevel, port, host, dataDir)
 	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write config file: %w", err)

--- a/examples/gastown/packs/gastown/overlay/.claude/settings.json
+++ b/examples/gastown/packs/gastown/overlay/.claude/settings.json
@@ -18,10 +18,6 @@
           {
             "type": "command",
             "command": "gc prime"
-          },
-          {
-            "type": "command",
-            "command": "gc handoff \"context cycle\""
           }
         ]
       }

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff \"context cycle\""
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **PreCompact hook crash fix**: `gc handoff "context cycle"` in the PreCompact hook calls `gc runtime request-restart`, which terminates the session entirely. This is catastrophic for the human-attended mayor session (kills it mid-conversation during compaction). Replaced with `gc prime` (safe context refresh) in both the embedded default config (`internal/hooks/config/claude.json`) and the pack overlay source (`examples/gastown/packs/gastown/overlay/.claude/settings.json`).

- **Dolt CPU storm fix**: `auto_gc_behavior` with `archive_level: 1` triggers dolt's archive process after every reconciler commit, causing 300-600% sustained CPU. Set to `enable: false, archive_level: 0`.

## Files changed

- `cmd/gc/cmd_dolt_config.go` — archive_level 1→0, enable true→false
- `internal/hooks/config/claude.json` — PreCompact: `gc handoff` → `gc prime`
- `examples/gastown/packs/gastown/overlay/.claude/settings.json` — PreCompact: removed `gc handoff` entry entirely

## Test plan

- [ ] Start city, trigger compaction in mayor session — verify mayor survives
- [ ] Monitor dolt CPU after reconciler commits — verify no archive storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted garbage collection configuration settings and behavior
  * Optimized database maintenance session hooks for pre-compaction operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->