### PR TITLE
fix: let pending creates bypass session sleep

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1962,7 +1962,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		eval.Policy = policy
 		name := target.session.Metadata["session_name"]
 		decision := awakeDecisions[name]
-		if decision.ShouldWake && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
+		if decision.ShouldWake && decision.Reason != "pending-create" && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
 			// Active demand (poolDesired > 0 or direct assigned work)
 			// overrides sleep suppression for non-interactive sessions
 			// (matching the old evaluateWakeReasons behavior). Interactive

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5384,6 +5384,55 @@ func TestReconcileSessionBeads_ConvergesPendingCreateWhenRuntimeMatchesBead(t *t
 	}
 }
 
+func TestReconcileSessionBeads_PendingCreateBypassesSessionSleepSuppression(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		SessionSleep: config.SessionSleepConfig{
+			InteractiveResume: "0s",
+		},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.markSessionCreating(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"pending_create_claim":       "true",
+	})
+
+	if woken := env.reconcile([]beads.Bead{session}); woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active", got.Metadata["state"])
+	}
+}
+
 func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpires(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary
- keep pending-create wake decisions from being suppressed by session-sleep policy
- add a regression covering an on-demand named session stuck in creating with pending_create_claim=true

## Tests
- go test ./cmd/gc -run 'TestReconcileSessionBeads_(PendingCreateBypassesSessionSleepSuppression|ConvergesPendingCreateWhenRuntimeMatchesBead|RollsBackPendingCreateOnProviderError|ConvergesPendingCreateOnLateSuccessStartError|HealsRunningPendingCreateToActive)|TestWakeReasonsNonInteractiveImmediateUsesHardWakeReasons|TestPhase2ReconcileSessionBeads_PinWakesThroughSessionSleepSuppression' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed session management to ensure sessions in pending-create state properly wake and transition to active status, regardless of configured session sleep suppression settings. Previously, these sessions were incorrectly blocked from waking due to configuration-based suppression rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/azanar/gascity/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->